### PR TITLE
Fix build with GHC 8.0 & aeson >= 0.10

### DIFF
--- a/ghcaniuse.cabal
+++ b/ghcaniuse.cabal
@@ -18,7 +18,7 @@ cabal-version:       >=1.10
 library
     exposed-modules: GHCanIUse
     hs-source-dirs:   src
-    build-depends:       base >=4.8 && <4.9, basic-prelude, scalpel, lens, parsec, time, turtle, text, aeson, bytestring, unordered-containers, lucid, transformers
+    build-depends:       base >=4.8 && <4.10, basic-prelude, scalpel, lens, parsec, time, turtle, text, aeson >= 0.10, bytestring, unordered-containers, lucid, transformers
     default-language:    Haskell2010
     default-extensions:  NoImplicitPrelude, OverloadedStrings
 
@@ -26,7 +26,7 @@ executable ghcaniuse
   main-is:             Main.hs
   -- other-modules:
   -- other-extensions:
-  build-depends:       base >=4.8 && <4.9, basic-prelude, scalpel, lens, parsec, time, turtle, text, aeson, bytestring, unordered-containers, lucid, transformers
+  build-depends:       base >=4.8 && <4.10, basic-prelude, scalpel, lens, parsec, time, turtle, text, aeson >= 0.10, bytestring, unordered-containers, lucid, transformers
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/src/GHCanIUse/Types.hs
+++ b/src/GHCanIUse/Types.hs
@@ -18,9 +18,6 @@ instance Eq GHCRelease where
     (GHCRelease _ (a,b,_)) == (GHCRelease _ (x,y,_)) = [a,b] == [x,y]
     _ == _ = False
 
-instance ToJSON Day where
-    toJSON = String . pack . showGregorian
-
 instance ToJSON GHCRelease
 
 instance Hashable Day where


### PR DESCRIPTION
In addition to that it would be great if you could update the website with the extensions for 8.0 (I don’t have nix setup so the script doesn’t work)
